### PR TITLE
Update tw-scratchx-compatibility-layer.js

### DIFF
--- a/src/extension-support/tw-scratchx-compatibility-layer.js
+++ b/src/extension-support/tw-scratchx-compatibility-layer.js
@@ -79,6 +79,11 @@ const parseScratchXArgument = (argument, defaultValue) => {
         const split = argument.split(/\.|:/);
         const menuName = split[1];
         result.menu = menuName;
+    } else if (argument === 'b') {
+        result.type = ArgumentType.BOOLEAN;
+        if (!hasDefaultValue) {
+            result.defaultValue = '';
+        }
     } else {
         throw new Error(`Unknown ScratchX argument type: ${argument}`);
     }


### PR DESCRIPTION
ScratchX has a Boolean argument type but the docs never mentioned it and TurboWarp never got it implemented.
Any ScratchX extension blocks that use it just error due to an unknown argument type and won't import.